### PR TITLE
Improve comic panel cropping

### DIFF
--- a/src/app/services/comic.service.ts
+++ b/src/app/services/comic.service.ts
@@ -78,37 +78,82 @@ export class ComicService {
   }
 
   processComicImage(file: File): Promise<string[]> {
+    const isRowMostlyWhite = (
+      ctx: CanvasRenderingContext2D,
+      y: number,
+      width: number,
+      threshold = 250,
+      ratio = 0.95
+    ): boolean => {
+      const data = ctx.getImageData(0, y, width, 1).data;
+      let whitePixels = 0;
+      for (let x = 0; x < width; x++) {
+        const i = x * 4;
+        if (data[i] >= threshold && data[i + 1] >= threshold && data[i + 2] >= threshold) {
+          whitePixels++;
+        }
+      }
+      return whitePixels / width > ratio;
+    };
+
+    const detectBottomWhiteMargin = (
+      ctx: CanvasRenderingContext2D,
+      width: number,
+      height: number
+    ): number => {
+      let margin = 0;
+      while (margin < height && isRowMostlyWhite(ctx, height - 1 - margin, width)) {
+        margin++;
+      }
+      return margin;
+    };
+
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
-      
+
       reader.onload = (e) => {
         const img = new Image();
         img.onload = () => {
+          const tempCanvas = document.createElement('canvas');
+          const tempCtx = tempCanvas.getContext('2d');
+
+          if (!tempCtx) {
+            reject(new Error('Could not get canvas context'));
+            return;
+          }
+
+          tempCanvas.width = img.width;
+          tempCanvas.height = img.height;
+          tempCtx.drawImage(img, 0, 0);
+
+          const bottomMargin = detectBottomWhiteMargin(tempCtx, img.width, img.height);
+
+          const topCrop = Math.min(Math.floor(img.height * 0.1), img.height - bottomMargin - 1);
+
+          const drawableHeight = img.height - topCrop - bottomMargin;
+          const panelWidth = img.width / 2;
+          const panelHeight = drawableHeight / 3;
+
           const canvas = document.createElement('canvas');
           const ctx = canvas.getContext('2d');
-          
+
           if (!ctx) {
             reject(new Error('Could not get canvas context'));
             return;
           }
-          
-          // Calculate panel dimensions (2 columns, 3 rows)
-          const panelWidth = img.width / 2;
-          const panelHeight = img.height / 3;
-          
+
           canvas.width = panelWidth;
           canvas.height = panelHeight;
-          
+
           const panels: string[] = [];
-          
-          // Extract each panel
+
           for (let row = 0; row < 3; row++) {
             for (let col = 0; col < 2; col++) {
               ctx.clearRect(0, 0, panelWidth, panelHeight);
               ctx.drawImage(
                 img,
                 col * panelWidth,
-                row * panelHeight,
+                topCrop + row * panelHeight,
                 panelWidth,
                 panelHeight,
                 0,
@@ -116,18 +161,18 @@ export class ComicService {
                 panelWidth,
                 panelHeight
               );
-              
+
               panels.push(canvas.toDataURL('image/jpeg', 0.9));
             }
           }
-          
+
           resolve(panels);
         };
-        
+
         img.onerror = () => reject(new Error('Failed to load image'));
         img.src = e.target?.result as string;
       };
-      
+
       reader.onerror = () => reject(new Error('Failed to read file'));
       reader.readAsDataURL(file);
     });

--- a/src/utils/imageProcessor.ts
+++ b/src/utils/imageProcessor.ts
@@ -1,35 +1,72 @@
+const isRowMostlyWhite = (ctx: CanvasRenderingContext2D, y: number, width: number, threshold = 250, ratio = 0.95): boolean => {
+  const data = ctx.getImageData(0, y, width, 1).data;
+  let whitePixels = 0;
+  for (let x = 0; x < width; x++) {
+    const i = x * 4;
+    if (data[i] >= threshold && data[i + 1] >= threshold && data[i + 2] >= threshold) {
+      whitePixels++;
+    }
+  }
+  return whitePixels / width > ratio;
+};
+
+const detectBottomWhiteMargin = (ctx: CanvasRenderingContext2D, width: number, height: number): number => {
+  let margin = 0;
+  while (margin < height && isRowMostlyWhite(ctx, height - 1 - margin, width)) {
+    margin++;
+  }
+  return margin;
+};
+
 export const processComicImage = (file: File): Promise<string[]> => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
-    
+
     reader.onload = (e) => {
       const img = new Image();
       img.onload = () => {
+        const tempCanvas = document.createElement('canvas');
+        const tempCtx = tempCanvas.getContext('2d');
+
+        if (!tempCtx) {
+          reject(new Error('Could not get canvas context'));
+          return;
+        }
+
+        tempCanvas.width = img.width;
+        tempCanvas.height = img.height;
+        tempCtx.drawImage(img, 0, 0);
+
+        const bottomMargin = detectBottomWhiteMargin(tempCtx, img.width, img.height);
+
+        // Remove title area (approx. 10% of the image height)
+        const topCrop = Math.min(Math.floor(img.height * 0.1), img.height - bottomMargin - 1);
+
+        // Calculate panel dimensions using the remaining drawable area
+        const drawableHeight = img.height - topCrop - bottomMargin;
+        const panelWidth = img.width / 2;
+        const panelHeight = drawableHeight / 3;
+
         const canvas = document.createElement('canvas');
         const ctx = canvas.getContext('2d');
-        
+
         if (!ctx) {
           reject(new Error('Could not get canvas context'));
           return;
         }
-        
-        // Calculate panel dimensions (2 columns, 3 rows)
-        const panelWidth = img.width / 2;
-        const panelHeight = img.height / 3;
-        
+
         canvas.width = panelWidth;
         canvas.height = panelHeight;
-        
+
         const panels: string[] = [];
-        
-        // Extract each panel
+
         for (let row = 0; row < 3; row++) {
           for (let col = 0; col < 2; col++) {
             ctx.clearRect(0, 0, panelWidth, panelHeight);
             ctx.drawImage(
               img,
               col * panelWidth,
-              row * panelHeight,
+              topCrop + row * panelHeight,
               panelWidth,
               panelHeight,
               0,
@@ -37,18 +74,18 @@ export const processComicImage = (file: File): Promise<string[]> => {
               panelWidth,
               panelHeight
             );
-            
+
             panels.push(canvas.toDataURL('image/jpeg', 0.9));
           }
         }
-        
+
         resolve(panels);
       };
-      
+
       img.onerror = () => reject(new Error('Failed to load image'));
       img.src = e.target?.result as string;
     };
-    
+
     reader.onerror = () => reject(new Error('Failed to read file'));
     reader.readAsDataURL(file);
   });


### PR DESCRIPTION
## Summary
- refine image processor to avoid cutting artwork
- update comic service with the same logic

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e64ad0f2c832cb361f0003578d944