### PR TITLE
Fix comic panel cropping to detect top white margin

### DIFF
--- a/src/app/services/comic.service.ts
+++ b/src/app/services/comic.service.ts
@@ -108,6 +108,18 @@ export class ComicService {
       return margin;
     };
 
+    const detectTopWhiteMargin = (
+      ctx: CanvasRenderingContext2D,
+      width: number,
+      height: number
+    ): number => {
+      let margin = 0;
+      while (margin < height && isRowMostlyWhite(ctx, margin, width)) {
+        margin++;
+      }
+      return margin;
+    };
+
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
 
@@ -128,7 +140,7 @@ export class ComicService {
 
           const bottomMargin = detectBottomWhiteMargin(tempCtx, img.width, img.height);
 
-          const topCrop = Math.min(Math.floor(img.height * 0.1), img.height - bottomMargin - 1);
+          const topCrop = detectTopWhiteMargin(tempCtx, img.width, img.height - bottomMargin);
 
           const drawableHeight = img.height - topCrop - bottomMargin;
           const panelWidth = img.width / 2;

--- a/src/utils/imageProcessor.ts
+++ b/src/utils/imageProcessor.ts
@@ -18,6 +18,14 @@ const detectBottomWhiteMargin = (ctx: CanvasRenderingContext2D, width: number, h
   return margin;
 };
 
+const detectTopWhiteMargin = (ctx: CanvasRenderingContext2D, width: number, height: number): number => {
+  let margin = 0;
+  while (margin < height && isRowMostlyWhite(ctx, margin, width)) {
+    margin++;
+  }
+  return margin;
+};
+
 export const processComicImage = (file: File): Promise<string[]> => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -38,9 +46,7 @@ export const processComicImage = (file: File): Promise<string[]> => {
         tempCtx.drawImage(img, 0, 0);
 
         const bottomMargin = detectBottomWhiteMargin(tempCtx, img.width, img.height);
-
-        // Remove title area (approx. 10% of the image height)
-        const topCrop = Math.min(Math.floor(img.height * 0.1), img.height - bottomMargin - 1);
+        const topCrop = detectTopWhiteMargin(tempCtx, img.width, img.height - bottomMargin);
 
         // Calculate panel dimensions using the remaining drawable area
         const drawableHeight = img.height - topCrop - bottomMargin;


### PR DESCRIPTION
## Summary
- adjust image processor to detect top white margin before slicing
- update Angular comic service to use the new top margin detection

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e67800afc832ca5413098ef0ca4a2