### PR TITLE
Fix comic service typing errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.0",
-    "pouchdb": "^8.0.1"
+    "pouchdb": "^8.0.1",
+    "pouchdb-browser": "^8.0.1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^17.0.0",


### PR DESCRIPTION
## Summary
- include `pouchdb-browser` dependency
- use `pouchdb-browser` in services
- refine `ComicDoc` types and add generics
- type callback params in comic service and storage helpers

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6c8e1cb4832c8155c7ea19e796e6