### PR TITLE
Fix PouchDB import build error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
+    "allowSyntheticDefaultImports": true,
     "target": "ES2022",
     "module": "ES2022",
     "useDefineForClassFields": false,


### PR DESCRIPTION
## Summary
- allow synthetic default imports in TypeScript

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6ec8db28832c844802d63f202e4b