### PR TITLE
Improve comic reader UI

### DIFF
--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -35,6 +35,17 @@
     <ion-row>
       <ion-col size="12" size-sm="6" size-md="4" size-lg="3" *ngFor="let comic of comics">
         <ion-card class="comic-card" (click)="readComic(comic)">
+          <div class="card-actions">
+            <ion-button
+              fill="clear"
+              size="small"
+              color="danger"
+              (click)="confirmDelete(comic, $event)"
+              class="delete-btn">
+              <ion-icon name="trash" slot="icon-only"></ion-icon>
+            </ion-button>
+          </div>
+
           <ion-img [src]="comic.coverImage" [alt]="comic.title" class="comic-cover"></ion-img>
           
           <ion-card-header>
@@ -147,6 +158,18 @@
       </ion-content>
     </ng-template>
   </ion-modal>
+
+  <!-- Delete confirmation alert -->
+  <ion-alert
+    [isOpen]="showDeleteAlert"
+    header="Supprimer la BD"
+    message="Etes-vous sur de vouloir supprimer cette BD ?"
+    [buttons]="[
+      { text: 'Annuler', role: 'cancel' },
+      { text: 'Supprimer', role: 'destructive' }
+    ]"
+    (ionAlertDidDismiss)="onAlertDismiss($event)">
+  </ion-alert>
 
   <!-- Toast -->
   <ion-toast

--- a/src/app/pages/home/home.page.scss
+++ b/src/app/pages/home/home.page.scss
@@ -88,6 +88,27 @@ ion-card.comic-card {
   &:hover {
     transform: translateY(-4px);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+    .card-actions {
+      opacity: 1;
+    }
+  }
+}
+
+.card-actions {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 10;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+
+  .delete-btn {
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: 50%;
+    --padding-start: 8px;
+    --padding-end: 8px;
+    --padding-top: 8px;
+    --padding-bottom: 8px;
   }
 }
 

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -3,36 +3,37 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
-import {
-  IonContent,
-  IonHeader,
-  IonTitle,
-  IonToolbar,
-  IonFab,
-  IonFabButton,
-  IonIcon,
-  IonGrid,
-  IonRow,
-  IonCol,
-  IonCard,
-  IonCardHeader,
-  IonCardTitle,
-  IonCardContent,
-  IonButton,
-  IonButtons,
-  IonModal,
-  IonItem,
-  IonLabel,
-  IonInput,
-  IonTextarea,
-  IonDatetime,
-  IonProgressBar,
-  IonToast,
-  IonImg,
-  IonText,
-  IonBadge,
-  IonChip
-} from '@ionic/angular/standalone';
+  import {
+    IonContent,
+    IonHeader,
+    IonTitle,
+    IonToolbar,
+    IonFab,
+    IonFabButton,
+    IonIcon,
+    IonGrid,
+    IonRow,
+    IonCol,
+    IonCard,
+    IonCardHeader,
+    IonCardTitle,
+    IonCardContent,
+    IonButton,
+    IonButtons,
+    IonModal,
+    IonItem,
+    IonLabel,
+    IonInput,
+    IonTextarea,
+    IonDatetime,
+    IonProgressBar,
+    IonToast,
+    IonImg,
+    IonText,
+    IonBadge,
+    IonChip,
+    IonAlert
+  } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import { add, book, heart, star, starOutline, calendar, trash } from 'ionicons/icons';
 import { ComicService } from '../../services/comic.service';
@@ -73,7 +74,8 @@ import { Comic } from '../../models/comic.model';
     IonImg,
     IonText,
     IonBadge,
-    IonChip
+    IonChip,
+    IonAlert
   ],
 })
 export class HomePage implements OnInit, OnDestroy {
@@ -82,6 +84,8 @@ export class HomePage implements OnInit, OnDestroy {
   isProcessing = false;
   showToast = false;
   toastMessage = '';
+  showDeleteAlert = false;
+  comicToDelete: Comic | null = null;
   
   newComic = {
     title: '',
@@ -177,6 +181,35 @@ export class HomePage implements OnInit, OnDestroy {
   updateRating(comic: Comic, rating: number, event: Event) {
     event.stopPropagation();
     this.comicService.updateComic(comic.id, { rating });
+  }
+
+  confirmDelete(comic: Comic, event: Event) {
+    event.stopPropagation();
+    this.comicToDelete = comic;
+    this.showDeleteAlert = true;
+  }
+
+  deleteComic() {
+    if (this.comicToDelete) {
+      this.comicService.deleteComic(this.comicToDelete.id);
+      this.showToastMessage('BD supprimée avec succès');
+      this.comicToDelete = null;
+    }
+    this.showDeleteAlert = false;
+  }
+
+  cancelDelete() {
+    this.comicToDelete = null;
+    this.showDeleteAlert = false;
+  }
+
+  onAlertDismiss(event: any) {
+    const role = event.detail.role;
+    if (role === 'destructive') {
+      this.deleteComic();
+    } else {
+      this.cancelDelete();
+    }
   }
 
   goToFavorites() {

--- a/src/app/pages/reader/reader.page.html
+++ b/src/app/pages/reader/reader.page.html
@@ -39,13 +39,15 @@
       <ion-icon name="chevron-back" slot="icon-only"></ion-icon>
     </ion-button>
 
-    <div class="panel-wrapper">
-      <ion-img 
-        [src]="comic.panels[currentPanel]" 
-        [alt]="'Panel ' + (currentPanel + 1)"
-        class="panel-image">
-      </ion-img>
-    </div>
+      <div class="panel-wrapper">
+        <ion-img
+          [src]="comic.panels[currentPanel]"
+          [alt]="'Panel ' + (currentPanel + 1)"
+          class="panel-image"
+          [class.zoomed]="isZoomed"
+          (click)="toggleZoom()">
+        </ion-img>
+      </div>
 
     <ion-button 
       fill="clear" 

--- a/src/app/pages/reader/reader.page.scss
+++ b/src/app/pages/reader/reader.page.scss
@@ -32,7 +32,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    max-width: 90%;
+    max-width: 100%;
   }
 
   .panel-image {
@@ -41,6 +41,13 @@
     object-fit: contain;
     border-radius: 8px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    cursor: zoom-in;
+
+    &.zoomed {
+      max-height: none;
+      width: 100%;
+      cursor: zoom-out;
+    }
   }
 
   .nav-button {

--- a/src/app/pages/reader/reader.page.ts
+++ b/src/app/pages/reader/reader.page.ts
@@ -60,6 +60,7 @@ import { Comic } from '../../models/comic.model';
 export class ReaderPage implements OnInit {
   comic: Comic | undefined = undefined;
   currentPanel = 0;
+  isZoomed = false;
 
   constructor(
     private route: ActivatedRoute,
@@ -126,6 +127,10 @@ export class ReaderPage implements OnInit {
 
   goToPanel(index: number) {
     this.currentPanel = index;
+  }
+
+  toggleZoom() {
+    this.isZoomed = !this.isZoomed;
   }
 
   toggleFavorite() {


### PR DESCRIPTION
## Summary
- allow deleting comics from the home screen
- enlarge reader panels and support zoom toggle
- show delete button overlay on comic cards

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ebcde0ba0832cb884e7f8baba4bc6