### PR TITLE
Add generator page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -17,5 +17,9 @@ export const routes: Routes = [
   {
     path: 'reader/:id',
     loadComponent: () => import('./pages/reader/reader.page').then(m => m.ReaderPage)
+  },
+  {
+    path: 'generator',
+    loadComponent: () => import('./pages/generator/generator.page').then(m => m.GeneratorPage)
   }
 ];

--- a/src/app/pages/generator/generator.page.html
+++ b/src/app/pages/generator/generator.page.html
@@ -1,0 +1,38 @@
+<ion-header [translucent]="true">
+  <ion-toolbar color="primary">
+    <ion-buttons slot="start">
+      <ion-button (click)="goBack()">
+        <ion-icon name="arrowBack" slot="icon-only"></ion-icon>
+      </ion-button>
+    </ion-buttons>
+    <ion-title>
+      <ion-icon name="construct" slot="start"></ion-icon>
+      Générateur
+    </ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content [fullscreen]="true">
+  <ion-item>
+    <ion-label position="stacked">Texte de la bulle</ion-label>
+    <ion-input [(ngModel)]="speech" placeholder="Entrer le texte"></ion-input>
+  </ion-item>
+
+  <ion-item>
+    <ion-label position="stacked">Expression</ion-label>
+    <ion-select [(ngModel)]="expression">
+      <ion-select-option value="happy">Heureux</ion-select-option>
+      <ion-select-option value="sad">Triste</ion-select-option>
+      <ion-select-option value="surprised">Surpris</ion-select-option>
+    </ion-select>
+  </ion-item>
+
+  <ion-button expand="full" (click)="generate()">Générer</ion-button>
+
+  <ion-card *ngIf="generated">
+    <ion-card-content class="preview-card">
+      <img [src]="imageMap[expression]" alt="expression" />
+      <div class="speech">{{ speech }}</div>
+    </ion-card-content>
+  </ion-card>
+</ion-content>

--- a/src/app/pages/generator/generator.page.scss
+++ b/src/app/pages/generator/generator.page.scss
@@ -1,0 +1,20 @@
+.preview-card {
+  position: relative;
+  text-align: center;
+}
+
+.preview-card img {
+  width: 100%;
+  height: auto;
+}
+
+.preview-card .speech {
+  position: absolute;
+  top: 10%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: white;
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid #333;
+}

--- a/src/app/pages/generator/generator.page.ts
+++ b/src/app/pages/generator/generator.page.ts
@@ -1,0 +1,70 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import {
+  IonContent,
+  IonHeader,
+  IonTitle,
+  IonToolbar,
+  IonButtons,
+  IonButton,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonInput,
+  IonSelect,
+  IonSelectOption,
+  IonCard,
+  IonCardContent
+} from '@ionic/angular/standalone';
+import { addIcons } from 'ionicons';
+import { arrowBack, construct } from 'ionicons/icons';
+
+@Component({
+  selector: 'app-generator',
+  templateUrl: './generator.page.html',
+  styleUrls: ['./generator.page.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonContent,
+    IonHeader,
+    IonTitle,
+    IonToolbar,
+    IonButtons,
+    IonButton,
+    IonIcon,
+    IonItem,
+    IonLabel,
+    IonInput,
+    IonSelect,
+    IonSelectOption,
+    IonCard,
+    IonCardContent
+  ]
+})
+export class GeneratorPage {
+  speech = '';
+  expression: 'happy' | 'sad' | 'surprised' = 'happy';
+  generated = false;
+
+  imageMap: Record<string, string> = {
+    happy: 'assets/generator/happy.svg',
+    sad: 'assets/generator/sad.svg',
+    surprised: 'assets/generator/surprised.svg'
+  };
+
+  constructor(private router: Router) {
+    addIcons({ arrowBack, construct });
+  }
+
+  goBack() {
+    this.router.navigate(['/home']);
+  }
+
+  generate() {
+    this.generated = true;
+  }
+}

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -8,6 +8,9 @@
       <ion-button (click)="goToFavorites()">
         <ion-icon name="heart" slot="icon-only"></ion-icon>
       </ion-button>
+      <ion-button (click)="goToGenerator()">
+        <ion-icon name="construct" slot="icon-only"></ion-icon>
+      </ion-button>
     </ion-buttons>
   </ion-toolbar>
 </ion-header>

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -35,7 +35,7 @@ import { Subscription } from 'rxjs';
     IonAlert
   } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
-import { add, book, heart, star, starOutline, calendar, trash } from 'ionicons/icons';
+import { add, book, heart, star, starOutline, calendar, trash, construct } from 'ionicons/icons';
 import { ComicService } from '../../services/comic.service';
 import { Comic } from '../../models/comic.model';
 
@@ -99,7 +99,7 @@ export class HomePage implements OnInit, OnDestroy {
     private comicService: ComicService,
     private router: Router
   ) {
-    addIcons({ add, book, heart, star, starOutline, calendar, trash });
+    addIcons({ add, book, heart, star, starOutline, calendar, trash, construct });
   }
 
   ngOnInit() {
@@ -214,6 +214,10 @@ export class HomePage implements OnInit, OnDestroy {
 
   goToFavorites() {
     this.router.navigate(['/favorites']);
+  }
+
+  goToGenerator() {
+    this.router.navigate(['/generator']);
   }
 
   private showToastMessage(message: string) {

--- a/src/assets/generator/happy.svg
+++ b/src/assets/generator/happy.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#ffe28a" stroke="#333" stroke-width="2"/>
+  <circle cx="35" cy="40" r="5" fill="#333"/>
+  <circle cx="65" cy="40" r="5" fill="#333"/>
+  <path d="M35 60 Q50 75 65 60" fill="none" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/src/assets/generator/sad.svg
+++ b/src/assets/generator/sad.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#ffe28a" stroke="#333" stroke-width="2"/>
+  <circle cx="35" cy="40" r="5" fill="#333"/>
+  <circle cx="65" cy="40" r="5" fill="#333"/>
+  <path d="M35 65 Q50 50 65 65" fill="none" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/src/assets/generator/surprised.svg
+++ b/src/assets/generator/surprised.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#ffe28a" stroke="#333" stroke-width="2"/>
+  <circle cx="35" cy="40" r="5" fill="#333"/>
+  <circle cx="65" cy="40" r="5" fill="#333"/>
+  <circle cx="50" cy="65" r="7" fill="none" stroke="#333" stroke-width="3"/>
+</svg>


### PR DESCRIPTION
## Summary
- create a Generator page with simple preview and expression selector
- wire the page in Angular routes
- add navigation button from the home page
- include placeholder face SVGs

## Testing
- `npm test` *(fails: `ng` not found)*
- `npm run lint` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec28e6728832ca5d5404f135d309d